### PR TITLE
Enhanced destroy method to null fields.

### DIFF
--- a/src/org/vaadin/artur/icepush/ICEPushServlet.java
+++ b/src/org/vaadin/artur/icepush/ICEPushServlet.java
@@ -86,5 +86,7 @@ public class ICEPushServlet extends ApplicationServlet {
     public void destroy() {
         super.destroy();
         ICEPushServlet.shutdown();
+        ICEPushServlet = null;
+        javascriptProvider = null;
     }
 }


### PR DESCRIPTION
Avoids a class loader leak: the MainServlet holds a reference to the WebAppClassloader and creates a leak on stop/undeploy.
Nulling it makes it available to the GC.
